### PR TITLE
Fix package

### DIFF
--- a/pyfmt.el
+++ b/pyfmt.el
@@ -34,6 +34,7 @@
   :type 'string
   :group 'pyfmt)
 
+;;;###autoload
 (defun pyfmt ()
   "Format the current buffer according to the pyfmt tool."
   (interactive)

--- a/pyfmt.el
+++ b/pyfmt.el
@@ -1,4 +1,4 @@
-;;; pyfmt.el --- Emacs interface to pyfmt -*- lexical-binding: t -*-
+;;; pyfmt.el --- Emacs interface to pyfmt
 
 ;; Copyright (C) 2015 Alexandre Héaumé.
 


### PR DESCRIPTION
- add autoload cookie for lazy loading
- Remove lexical-binding setting. lexical-binding was introduced at Emacs 24 so it does not work Emacs 23. And it makes no sense because there is no `let` in this program.
